### PR TITLE
Changing number to local_num as number is not a key in dict

### DIFF
--- a/simplejira/prompt.py
+++ b/simplejira/prompt.py
@@ -239,7 +239,7 @@ class CardEditor(BasePrompt):
 
             print("Available statuses:\n\n")
             for status in avail_statuses:
-                print("  {}) {}".format(status['number'], status['friendly_name']))
+                print("  {}) {}".format(status['local_num'], status['friendly_name']))
             while True:
                 new_id = self._jw.get_avail_status_id(
                     avail_statuses,


### PR DESCRIPTION
Fixed KeyError 
It was failing as : 
 (card RHCFQE-7045) status 
Available statuses:


Traceback (most recent call last):
  File "/home/kkulkarn/git/simplejira/venv/lib/python2.7/site-packages/cmd2.py", line 981, in onecmd_plus_hooks
    stop = self.onecmd(statement)
  File "/home/kkulkarn/git/simplejira/venv/lib/python2.7/site-packages/cmd2.py", line 1179, in onecmd
    stop = func(statement)
  File "/home/kkulkarn/git/simplejira/venv/lib/python2.7/site-packages/cmd2.py", line 329, in cmd_wrapper
    func(instance, args)
  File "simplejira/prompt.py", line 205, in do_status
    print("Statuses {}", status)
KeyError: 'number'
EXCEPTION of type 'KeyError' occurred with message: ''number''
To enable full traceback, run the following command:  'set debug true'
