### PR TITLE
Adding ability to search(filter ls output) by title(also called summrry) of a Jira card

### DIFF
--- a/simplejira/prompt.py
+++ b/simplejira/prompt.py
@@ -75,6 +75,9 @@ class Prompt(cmd2.Cmd):
     ls_parser.add_argument(
         '-S', '--status', type=str, default=None,
         help='Status of the card. e.g. "inprogress" or "In Progress"')
+    ls_parser.add_argument(
+        '-t', '--text', type=str, default=None,
+        help='Search by text in title or description of the card e.g. --text "5.8 BZs"')
     @cmd2.with_argparser(ls_parser)
     def do_ls(self, args):
         sprint = None
@@ -86,9 +89,7 @@ class Prompt(cmd2.Cmd):
         status = None
         if args.status:
             status = self._jw.find_status_name(args.status)
-
-
-        issues = self._jw.search_issues(args.user, sprint, status)
+        issues = self._jw.search_issues(args.user, sprint, status, args.text)
         self.issue_collection = issue_collection(issues)
         self.issue_collection.print_table()
 

--- a/simplejira/wrapper.py
+++ b/simplejira/wrapper.py
@@ -292,7 +292,7 @@ class JiraWrapper(object):
             self.get_current_sprint()
         return self._current_sprint_name
 
-    def search_issues(self, sprint=None, assignee=None, status=None):
+    def search_issues(self, sprint=None, assignee=None, status=None, text=None):
         """
         Search issues
 
@@ -300,7 +300,7 @@ class JiraWrapper(object):
            sprint: sprint ID number, sprint name, or "backlog", default is current sprint
            assignee: user id, default is "currentUser"
            status: for e.x. "in progress"
-        
+
         Returns:
             List of JIRA.Issue resources
         """
@@ -311,6 +311,8 @@ class JiraWrapper(object):
         search_query = 'sprint = {} AND assignee = {}'.format(sprint, assignee)
         if status:
             search_query += ' AND status in ("{}")'.format(status)
+        if text:
+            search_query += ' AND (summary ~ "{}" OR description ~ "{}")'.format(text, text)
         return self.jira.search_issues(search_query)
 
     def get_my_issues(self):


### PR DESCRIPTION
Adding ability to search(filter ls output) by title(also called summrry) of a Jira card

Can be run as:

1)` ls --text VMRC`

or 

2)` ls -t vmrc`

or

3)` ls --text "VMRC Tests"`

Quotes required for multiword search, single word search not reuired, its case insensitive search, 1st two commands will yield same results.

Internally search query would look like :   'sprint = 4503 AND assignee = currentUser() AND (summary ~ "ansible bugzilla" OR description ~ "ansible bugzilla")'

So it will try to match summary OR description and whichever yields match would get the output.
