### PR TITLE
When it is possible to find exactly matching component, return it

### DIFF
--- a/jiraprompt/wrapper.py
+++ b/jiraprompt/wrapper.py
@@ -486,8 +486,13 @@ class JiraWrapper(object):
           tuple of (component_name, component_id)
         """
         components = self.jira.project_components(self.project_id)
+        # First, try exact match
         for c in components:
-            if (str(txt).isdigit and str(c.id) == str(txt)) or str(txt).lower() in c.name.lower():
+            if (str(txt).isdigit and str(c.id) == str(txt)) or str(txt).lower() == c.name.lower():
+                return c.name, c.id
+        # Second, if we are still here, try fuzzy match
+        for c in components:
+            if str(txt).lower() in c.name.lower():
                 return c.name, c.id
         raise ValueError("Unable to find component with text: ", str(txt))
 


### PR DESCRIPTION
In out project we have these components:

 * Config Management
 * Management

and when I'm creating a new issue with *Management* component, this `find_component` method keeps returning *Config Management*. This patch changes it so it first tries to find exact match and only if it fails to do so, it tries that `in` fuzzy match.